### PR TITLE
Compatibility with latest Grbl (1.1f)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 PLATFORM   = LINUX
 
 #The original grbl code, except those files overriden by sim
-GRBL_BASE_OBJECTS =   ../protocol.o ../planner.o ../settings.o ../print.o ../nuts_bolts.o  ../stepper.o ../gcode.o ../spindle_control.o ../motion_control.o ../limits.o ../coolant_control.o ../probe.o ../system.o 
+GRBL_BASE_OBJECTS =   ../protocol.o ../planner.o ../settings.o ../print.o ../nuts_bolts.o  ../stepper.o ../gcode.o ../spindle_control.o ../motion_control.o ../limits.o ../coolant_control.o ../probe.o ../system.o ../jog.o 
 # grbl files that have simulator overrrides 
 GRBL_OVERRIDE_OBJECTS =  ../main.o ../serial.o ../report.o
 
@@ -29,10 +29,10 @@ GRBL_OVERRIDE_OBJECTS =  ../main.o ../serial.o ../report.o
 AVR_OBJECTS  = avr/interrupt.o avr/pgmspace.o  avr/io.o  avr/eeprom.o grbl_eeprom_extensions.o
 
 # Simulator Only Objects
-SIM_OBJECTS = main.o simulator.o serial.o util/delay.o util/floatunsisf.o platform_$(PLATFORM).o
+SIM_OBJECTS = main.o simulator.o serial.o util/delay.o util/floatunsisf.o platform_$(PLATFORM).o system_declares.o
 
 GRBL_SIM_OBJECTS = grbl_interface.o  $(GRBL_BASE_OBJECTS) $(GRBL_OVERRIDE_OBJECTS) $(SIM_OBJECTS) $(AVR_OBJECTS)
-GRBL_VAL_OBJECTS = validator.o overridden_report.o $(GRBL_BASE_OBJECTS) $(AVR_OBJECTS)
+GRBL_VAL_OBJECTS = validator.o overridden_report.o $(GRBL_BASE_OBJECTS) $(AVR_OBJECTS) system_declares.o
 
 CLOCK      = 16000000
 SIM_EXE_NAME   = grbl_sim.exe

--- a/avr/io.h
+++ b/avr/io.h
@@ -166,6 +166,7 @@ volatile extern io_sim_t io;
 #define CS11 1
 #define CS10 0
 #define CS21 1
+#define CS22 2
 
 #define WGM13 4
 #define WGM12 3

--- a/config.h
+++ b/config.h
@@ -21,11 +21,13 @@
 */
 
 #ifndef config_h
-
+#define __flash
 // Include grbl's system.h, not its config.h, 
 // because of circular dependency (config.h includes system.h which includes config.h).
 // This way ensures that the CPU Map and other config flags are set before they are needed
 #include "../system.h"
+
+
 
 #endif
 

--- a/grbl_interface.c
+++ b/grbl_interface.c
@@ -81,7 +81,7 @@ void print_steps(bool force)
   plan_block_t* current_block = plan_get_current_block();
   int ocr = 0;
   #ifdef VARIABLE_SPINDLE
-  if(TCCRA_REGISTER >= 127) ocr = OCR_REGISTER;
+  if(SPINDLE_TCCRA_REGISTER >= 127) ocr = SPINDLE_OCR_REGISTER;
   #endif
 
   //Allow exit when idle. Prevents aborting before all streamed commands have run
@@ -91,7 +91,7 @@ void print_steps(bool force)
   if (current_block != printed_block ) {
    //new block. 
    if (block_number) { //print values from the end of prev block
-     fprintf(args.step_out_file, "%12.5f %d, %d, %d, %d\n", sim.sim_time, sys.position[X_AXIS], sys.position[Y_AXIS], sys.position[Z_AXIS],ocr);
+     fprintf(args.step_out_file, "%12.5f %d, %d, %d, %d\n", sim.sim_time, sys_position[X_AXIS], sys_position[Y_AXIS], sys_position[Z_AXIS],ocr);
    }
    printed_block = current_block;
    if (current_block == NULL) { return; }
@@ -100,7 +100,7 @@ void print_steps(bool force)
   }
   //print at correct interval while executing block
   else if ((current_block && sim.sim_time>=next_print_time) || force ) {
-     fprintf(args.step_out_file, "%12.5f %d, %d, %d, %d\n", sim.sim_time, sys.position[X_AXIS], sys.position[Y_AXIS], sys.position[Z_AXIS],ocr);
+     fprintf(args.step_out_file, "%12.5f %d, %d, %d, %d\n", sim.sim_time, sys_position[X_AXIS], sys_position[Y_AXIS], sys_position[Z_AXIS],ocr);
    fflush(args.step_out_file);
 
    //make sure the simulation time doesn't get ahead of next_print_time

--- a/validator.c
+++ b/validator.c
@@ -157,6 +157,11 @@ uint8_t serial_get_rx_buffer_count() {
   return 0;  //not important for gcode validation
 }
 
+uint8_t serial_get_rx_buffer_available()
+{
+  return 0;
+}
+
 extern void orig_report_status_message(uint8_t);
 void report_status_message(uint8_t status_code)
 {


### PR DESCRIPTION
The simulator now compiles and executes with Grbl 1.1f.

Note that this change breaks compatibility with Grbl 0.9. Should we keep different branches?